### PR TITLE
Resolved multline bug, added some tests for it

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,21 @@ hook()
 x = 3 + "String"
 
 ```
+
+## Contribution
+
+`frosch` uses [poetry](https://github.com/python-poetry/poetry) for build and dependency
+management, so please install beforehand.
+
+### Setup
+
+```bash
+$ git clone https://github.com/HallerPatrick/frosch.git
+$ poetry install
+```
+
+### Run tests
+
+```python
+$ python -m pylint tests
+```

--- a/example/example.py
+++ b/example/example.py
@@ -11,7 +11,8 @@ def hello():
     z = [1, 2, "hel"]
     index = 0
     i = "Other string"
-    # x = y + z[index] + i + 4 + "ROFL"
+    x = (y + 
+        z[index] + i + 4 + "ROFL")
 
 
 def num():

--- a/frosch/writer.py
+++ b/frosch/writer.py
@@ -10,8 +10,6 @@
 
 """
 
-from __future__ import annotations
-
 import sys
 from typing import Any, List
 
@@ -36,7 +34,7 @@ class Variable:
         """str representation of a Variable object"""
         return "Variable({!r}, {}, {!r})".format(self.name, self.col_offset, self.value)
 
-    def __eq__(self, other: Variable):
+    def __eq__(self, other: "Variable"):
         """Mainly for testing purpose"""
         return self.__hash__() == other.__hash__()
 

--- a/frosch/writer.py
+++ b/frosch/writer.py
@@ -10,6 +10,8 @@
 
 """
 
+from __future__ import annotations
+
 import sys
 from typing import Any, List
 
@@ -33,6 +35,14 @@ class Variable:
     def __repr__(self):
         """str representation of a Variable object"""
         return "Variable({!r}, {}, {!r})".format(self.name, self.col_offset, self.value)
+
+    def __eq__(self, other: Variable):
+        """Mainly for testing purpose"""
+        return self.__hash__() == other.__hash__()
+
+    def __hash__(self):
+        """We don't care for unique hashes"""
+        return hash((self.name, self.col_offset, self.value))
 
     def tree_str(self):
         """Python>3.8 variable declaration format with types"""


### PR DESCRIPTION
In multiline statements the last stack only contains the first line. After trying to parse and fail, we look for the next lines and try to parse them as well, till a successful parsing is possible.